### PR TITLE
Added shiny sprite display for each pokemon

### DIFF
--- a/pokemonSearch/index.html
+++ b/pokemonSearch/index.html
@@ -21,11 +21,11 @@
         <div id="pokemon-info">
           <div>
             <span id="pokemon-name"></span>
-            <span id="pokemon-id"></span>
           </div>
     
           <div id="pokemon-image"></div>
-    
+          
+          <p id="pokemon-id"></p>
           <p id="weight"></p>
           <p id="height"></p>
           <div id="types"></div>

--- a/pokemonSearch/script.js
+++ b/pokemonSearch/script.js
@@ -37,28 +37,28 @@ const searchPokedex = async () => {
     pokemonImage.innerHTML = `
       <div id = "normal">
         <img src="${sprites.front_default}" id="sprite">
-        <p>Normal ${name}</p>
+        <p>Normal sprite</p>
       </div>
       <div id = "shiny">
         <img src="${sprites.front_shiny}" id="sprite">
-        <p>Shiny ${name}</p>
+        <p>Shiny sprite</p>
       </div>
       <div id = "shiny">
         <img src="${sprites.back_default}" id="sprite">
-        <p>Shiny ${name}</p>
+        <p>Back sprite</p>
       </div>
       <div id = "shiny">
         <img src="${sprites.back_shiny}" id="sprite">
-        <p>Shiny ${name}</p>
+        <p>Back sprite shiny</p>
       </div>
     `;
 
     // Update the HTML elements with the fetched Pokémon details
     pokemonName.innerHTML = name.toUpperCase(); // Display name 
-    pokemonId.innerHTML = `#${id}`; // Display Pokémon ID
+    pokemonId.innerHTML = `National dex number: ${id}`; // Display Pokémon ID
 
-    pokemonWeight.innerHTML = `Weight: ${weight}`; 
-    pokemonHeight.innerHTML = `Height: ${height}`;
+    pokemonWeight.innerHTML = `Weight: ${weight*0.1.toFixed(1)} kg`; 
+    pokemonHeight.innerHTML = `Height: ${height*0.1.toFixed(1)} m`;
     
     // Display types with appropriate styling based on type names
     pokemonTypes.innerHTML = types.map(type => `<span class="${type.type.name.toLowerCase()}">${type.type.name.toUpperCase()}</span>`).join(" ");

--- a/pokemonSearch/style.css
+++ b/pokemonSearch/style.css
@@ -35,11 +35,12 @@ h1 {
     display: flex;
     flex-direction: column;
     align-items: center;
-    background-color: rgb(0, 153, 255);
+    background-color: rgb(255, 0, 0);
     padding: 20px;
     border-radius: 8px;
     box-shadow: black 5px 5px;
-    width: 30%;
+    width: 60%;
+    max-width: 1000px;
     margin-bottom: 20px;
 }
 
@@ -100,7 +101,7 @@ label {
     text-align: center;
 }
 
-#weight, #height {
+#weight, #height, #pokemon-id {
     align-self: flex-start;
 }
 
@@ -123,6 +124,7 @@ table {
 td, th {
     background-color: #ffffff;
     padding: 10px;
+    border-radius: 5px;
 }
 
 /*Styling for pokemon types*/
@@ -204,13 +206,11 @@ td, th {
 @media screen and (max-width: 700px) {
     #pokedex {
         width: 90%;
-        margin-bottom: 5vh;
     }
 }
 
 @media screen and (min-width: 501px) and (max-width: 1100px) {
     #pokedex {
-        width: 50%;
-        margin-bottom: 5vh;
+        width: 70%;
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Earlier, when we searched for a Pokémon name, it only showed its normal sprite. When I analyzed the API response, I noticed that more sprites, like the shiny one, were also fetched but not displayed. So I updated the code, and now we can see the Pokémon in both normal and shiny forms....also added back sprites for both normal and shiny form...also changed the api used from FreeCodeCamp to PokeApi that provides a more detailed data that can be used by other contributers

## Test Plan

To test this type in the Pokémon name you will see the normal side along with shiny one alongside it

## Related PRs and Issues

nil

### Have you read the [Contributing Guidelines on issues](CONTRIBUTING.md)?

yes
