### PR TITLE
fix: added self match and and clue for card matching

### DIFF
--- a/Memory_Game/script.js
+++ b/Memory_Game/script.js
@@ -21,6 +21,7 @@ function createCard(letter) {
 
 function flipCard() {
     if (lockBoard) return;
+    if (this === firstCard) return;
 
     this.classList.add('flipped');
     this.textContent = this.dataset.letter;
@@ -45,6 +46,10 @@ function checkForMatch() {
 function disableCards() {
     firstCard.removeEventListener('click', flipCard);
     secondCard.removeEventListener('click', flipCard);
+
+    firstCard.classList.add('matched');
+    secondCard.classList.add('matched');
+
     resetBoard();
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!
-->

## What does this PR do?

This PR fixes two major issues in the **Memory Game** logic and improves user experience:

1. **Prevents Self-Matching:**  
   Previously, a player could click the same card twice and the game would register it as a correct match.  
   I fixed this by adding a condition in the `flipCard()` function that prevents selecting the same card twice.

2. **Adds Visual Cue for Matched Cards:**  
   Matched cards were disabled but looked identical to unflipped cards, providing no visual feedback.  
   I updated the `disableCards()` function to add a `matched` CSS class to matched cards, changing their appearance and clearly indicating that they are out of play.

These fixes ensure that the game behaves correctly and provides better feedback to the player.

---

## Test Plan

1. Open the **Memory Game** in your browser.  
2. Click the same card twice — it should no longer count as a match.  
3. Match two correct cards — they should now change color or style (via the `matched` class).  
4. Verify that matched cards cannot be flipped again.  
5. Confirm that the rest of the game logic works as expected.  
6. Check browser console to ensure there are no JavaScript errors.

---

## Related PRs and Issues

N/A — this PR directly fixes the self-matching and visual feedback bugs in the Memory Game.

---

### Have you read the [Contributing Guidelines on issues](CONTRIBUTING.md)?

Yes ✅

---

🎃 **Hacktoberfest Special:**  
This PR enhances both game logic and player experience — making the Memory Game more fair, dynamic, and visually engaging!
